### PR TITLE
Simplify normalization of confusion matrix

### DIFF
--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -170,9 +170,7 @@ def confusion_matrix(
 
     if normalize:
         for idx, row in enumerate(matrix):
-            if np.sum(row) == 0:
-                matrix[idx] = [0.] * len(labels)
-            else:
+            if np.sum(row) != 0:
                 row_sum = float(np.sum(row))
                 matrix[idx] = [x / row_sum for x in row]
 


### PR DESCRIPTION
This applies the changes discussed at https://github.com/audeering/audplot/pull/1#discussion_r654230738
and simplifies the normalization of the confusion matrix to

```python
    if normalize:
        for idx, row in enumerate(matrix):
            if np.sum(row) != 0:
                row_sum = float(np.sum(row))
                matrix[idx] = [x / row_sum for x in row]
```