### PR TITLE
Add audmetric.utils.infer_labels()

### DIFF
--- a/audmetric/__init__.py
+++ b/audmetric/__init__.py
@@ -1,3 +1,4 @@
+from audmetric import utils
 from audmetric.core.api import (
     accuracy,
     concordance_cc,

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -45,7 +45,8 @@ def accuracy(
 
     """
     assert_equal_length(truth, prediction)
-    labels = infer_labels(truth, prediction, labels)
+    if labels is None:
+        labels = infer_labels(truth, prediction)
 
     prediction = np.array(prediction)
     truth = np.array(truth)
@@ -154,7 +155,8 @@ def confusion_matrix(
 
     """
     assert_equal_length(truth, prediction)
-    labels = infer_labels(truth, prediction, labels)
+    if labels is None:
+        labels = infer_labels(truth, prediction)
 
     truth = np.array(truth)
     prediction = np.array(prediction)
@@ -323,7 +325,8 @@ def fscore_per_class(
         {0: 0.6666666666666666, 1: 0.0}
 
     """
-    labels = infer_labels(truth, prediction, labels)
+    if labels is None:
+        labels = infer_labels(truth, prediction)
 
     precision = precision_per_class(
         truth,
@@ -487,7 +490,8 @@ def precision_per_class(
         {0: 1.0, 1: 0.0}
 
     """
-    labels = infer_labels(truth, prediction, labels)
+    if labels is None:
+        labels = infer_labels(truth, prediction)
 
     matrix = np.array(confusion_matrix(truth, prediction, labels))
     total = matrix.sum(axis=0)
@@ -530,7 +534,8 @@ def recall_per_class(
         {0: 0.5, 1: 0.0}
 
     """
-    labels = infer_labels(truth, prediction, labels)
+    if labels is None:
+        labels = infer_labels(truth, prediction)
 
     matrix = np.array(confusion_matrix(truth, prediction, labels))
     total = matrix.sum(axis=1)
@@ -638,7 +643,8 @@ def unweighted_average_bias(
         0.5
 
     """
-    labels = infer_labels(truth, prediction, labels)
+    if labels is None:
+        labels = infer_labels(truth, prediction)
 
     if not len(truth) == len(prediction) == len(protected_variable):
         raise ValueError(

--- a/audmetric/core/utils.py
+++ b/audmetric/core/utils.py
@@ -18,26 +18,21 @@ def assert_equal_length(
 def infer_labels(
         truth: typing.Sequence[typing.Any],
         prediction: typing.Sequence[typing.Any],
-        labels: typing.Optional[typing.Sequence[typing.Any]],
-) -> typing.Sequence[typing.Any]:
+) -> typing.List[typing.Any]:
     r"""Infer labels from truth and prediction.
 
-    It gathers all labels that are present in the truth and prediction values.
+    It gathers all labels that are present
+    in the truth and prediction values.
 
     Args:
         truth: ground truth labels
         prediction: predicted labels
-        labels: if labels are provided,
-            they will not be infered
-            but simply returned as a sorted list
 
     Returns:
-        labels
+        labels in sorted order
 
     """
-    if labels is None:
-        labels = set(truth) | set(prediction)
-    return sorted(list(labels))
+    return sorted(list(set(truth) | set(prediction)))
 
 
 def scores_per_subgroup_and_class(

--- a/audmetric/core/utils.py
+++ b/audmetric/core/utils.py
@@ -20,10 +20,24 @@ def infer_labels(
         prediction: typing.Sequence[typing.Any],
         labels: typing.Optional[typing.Sequence[typing.Any]],
 ) -> typing.Sequence[typing.Any]:
-    r"""Infer labels from truth and prediction."""
+    r"""Infer labels from truth and prediction.
+
+    It gathers all labels that are present in the truth and prediction values.
+
+    Args:
+        truth: ground truth labels
+        prediction: predicted labels
+        labels: if labels are provided,
+            they will not be infered
+            but simply returned as a sorted list
+
+    Returns:
+        labels
+
+    """
     if labels is None:
-        labels = sorted(list(set(truth) | set(prediction)))
-    return labels
+        labels = set(truth) | set(prediction)
+    return sorted(list(labels))
 
 
 def scores_per_subgroup_and_class(

--- a/audmetric/utils/__init__.py
+++ b/audmetric/utils/__init__.py
@@ -1,0 +1,1 @@
+from audmetric.core.utils import infer_labels

--- a/docs/api-utils.rst
+++ b/docs/api-utils.rst
@@ -1,0 +1,9 @@
+audmetric.utils
+===============
+
+.. automodule:: audmetric.utils
+
+infer_labels
+------------
+
+.. autofunction:: infer_labels

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@
     :hidden:
 
     api
+    api-utils
     genindex
 
 .. toctree::


### PR DESCRIPTION
This makes `infer_labels()` available to the user. It might be useful as we apply it already in `audplot`.

I moved it under `audmetric.utils` as under `audmetric` we only have actual metric functions at the moment.

![image](https://user-images.githubusercontent.com/173624/122544281-f5729e00-d02c-11eb-8330-a21c130059b8.png)
