### PR TITLE
Update Python package metadata syntax

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,14 @@
 [metadata]
 name = audmetric
 author = Johannes Wagner, Hagen Wierstorf, Stephan Huber, Andreas Triantafyllopoulos, Uwe Reichel
-author-email = jwagner@audeering.com
+author_email = jwagner@audeering.com
 url = https://audeering.github.io/audmetric/
-project-urls =
+project_urls =
     Documentation = https://audeering.github.io/audmetric/
 description = Evaluate machine-learning models
-long-description = file: README.rst, CHANGELOG.rst
+long_description = file: README.rst, CHANGELOG.rst
 license = MIT
-license-file = LICENSE
+license_file = LICENSE
 keywords = mlops, machine learning
 platforms= any
 classifiers =


### PR DESCRIPTION
Replace deprecated `abc-def` entries with `abc_def` in `setup.cfg`.