### PR TITLE
DOC: fix abbreviation of mean_absolute_error()

### DIFF
--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -575,7 +575,7 @@ def mean_absolute_error(
 
     .. math::
 
-        \text{MSE} = \frac{1}{n} \sum^n_{i=1}
+        \text{MAE} = \frac{1}{n} \sum^n_{i=1}
             |\text{prediction} - \text{truth}|
 
     Args:


### PR DESCRIPTION
We named it `MSE` before. Corrected it to `MAE`:

![image](https://user-images.githubusercontent.com/173624/148987469-7a454c61-8c17-4eb5-9f15-62e1a032c1bf.png)
