### PR TITLE
Support pandas series with dtype Int64

### DIFF
--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -102,8 +102,8 @@ def concordance_cc(
     """
     assert_equal_length(truth, prediction)
 
-    prediction = np.array(prediction)
-    truth = np.array(truth)
+    prediction = np.array(list(prediction))
+    truth = np.array(list(truth))
 
     if len(prediction) < 2:
         return np.NaN
@@ -666,8 +666,8 @@ def pearson_cc(
     """
     assert_equal_length(truth, prediction)
 
-    prediction = np.array(prediction)
-    truth = np.array(truth)
+    prediction = np.array(list(prediction))
+    truth = np.array(list(truth))
 
     if len(prediction) < 2 or prediction.std() == 0:
         return np.NaN

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+pandas
 pyeer
 pytest
 pytest-flake8

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -86,7 +86,10 @@ def test_accuracy(truth, prediction, labels, to_string):
             )
             truth = truth[mask]
             prediction = prediction[mask]
-        accuracy = sklearn.metrics.accuracy_score(truth, prediction)
+        accuracy = sklearn.metrics.accuracy_score(
+            list(truth),
+            list(prediction),
+        )
 
     np.testing.assert_almost_equal(
         audmetric.accuracy(truth, prediction, labels=labels),
@@ -260,9 +263,15 @@ def test_event_error_rate(truth, prediction, eer):
         np.zeros(10),
     ),
 ])
-def test_concordancecc(truth, prediction):
+def test_concordance_cc(truth, prediction):
+
+    ccc = audmetric.concordance_cc(truth, prediction)
+
+    prediction = np.array(list(prediction))
+    truth = np.array(list(truth))
+
     if len(prediction) < 2:
-        ccc = np.NaN
+        ccc_expected = np.NaN
     else:
         denominator = (
             prediction.std() ** 2
@@ -270,13 +279,14 @@ def test_concordancecc(truth, prediction):
             + (prediction.mean() - truth.mean()) ** 2
         )
         if denominator == 0:
-            ccc = np.NaN
+            ccc_expected = np.NaN
         else:
-            r = np.corrcoef(prediction, truth)[0][1]
-            ccc = 2 * r * prediction.std() * truth.std() / denominator
+            r = np.corrcoef(list(prediction), list(truth))[0][1]
+            ccc_expected = 2 * r * prediction.std() * truth.std() / denominator
+
     np.testing.assert_almost_equal(
-        audmetric.concordance_cc(truth, prediction),
         ccc,
+        ccc_expected,
     )
 
 
@@ -413,11 +423,11 @@ def test_mean_squared_error(value_range, num_elements):
         np.zeros(10),
     ),
 ])
-def test_pearsoncc(truth, prediction):
+def test_pearson_cc(truth, prediction):
     if len(prediction) < 2 or prediction.std() == 0:
         pcc = np.NaN
     else:
-        pcc = np.corrcoef(truth, prediction)[0][1]
+        pcc = np.corrcoef(list(truth), list(prediction))[0][1]
     np.testing.assert_almost_equal(
         audmetric.pearson_cc(truth, prediction),
         pcc,
@@ -499,13 +509,9 @@ def test_recall_precision_fscore(truth, prediction, labels, zero_division):
             labels,
             zero_division=zero_division,
         )
-        if isinstance(truth, pd.Series):
-            truth = np.array(list(truth))
-        if isinstance(prediction, pd.Series):
-            prediction = np.array(list(prediction))
         expected = sklearn_metric(
-            truth,
-            prediction,
+            list(truth),
+            list(prediction),
             average='macro',
             zero_division=zero_division,
         ),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pandas as pd
 import pyeer.eer_info
 import pytest
 import sklearn.metrics
@@ -10,6 +11,12 @@ import audmetric
     (
         np.random.randint(0, 10, size=5),
         np.random.randint(0, 10, size=5),
+        None,
+        False,
+    ),
+    (
+        pd.Series(np.random.randint(0, 10, size=5)).astype('Int64'),
+        pd.Series(np.random.randint(0, 10, size=5)).astype('Int64'),
         None,
         False,
     ),
@@ -229,6 +236,10 @@ def test_event_error_rate(truth, prediction, eer):
         np.random.randint(0, 10, size=5),
     ),
     (
+        pd.Series(np.random.randint(0, 10, size=5)).astype('Int64'),
+        pd.Series(np.random.randint(0, 10, size=5)).astype('Int64'),
+    ),
+    (
         np.random.randint(0, 10, size=1),
         np.random.randint(0, 10, size=1),
     ),
@@ -329,8 +340,17 @@ def test_edit_distance(truth, prediction, edit_distance):
     ([0, 2], 100),
 ])
 def test_mean_absolute_error(value_range, num_elements):
+
     t = np.random.randint(value_range[0], value_range[1], size=num_elements)
     p = np.random.randint(value_range[0], value_range[1], size=num_elements)
+
+    np.testing.assert_almost_equal(
+        audmetric.mean_absolute_error(t, p),
+        sklearn.metrics.mean_absolute_error(t, p),
+    )
+
+    t = pd.Series(t).astype('Int64')
+    t = pd.Series(t).astype('Int64')
 
     np.testing.assert_almost_equal(
         audmetric.mean_absolute_error(t, p),
@@ -345,6 +365,7 @@ def test_mean_absolute_error(value_range, num_elements):
     ([0, 2], 100),
 ])
 def test_mean_squared_error(value_range, num_elements):
+
     t = np.random.randint(value_range[0], value_range[1], size=num_elements)
     p = np.random.randint(value_range[0], value_range[1], size=num_elements)
 
@@ -353,11 +374,23 @@ def test_mean_squared_error(value_range, num_elements):
         sklearn.metrics.mean_squared_error(t, p),
     )
 
+    t = pd.Series(t).astype('Int64')
+    t = pd.Series(t).astype('Int64')
+
+    np.testing.assert_almost_equal(
+        audmetric.mean_absolute_error(t, p),
+        sklearn.metrics.mean_absolute_error(t, p),
+    )
+
 
 @pytest.mark.parametrize('truth,prediction', [
     (
         np.random.randint(0, 10, size=5),
         np.random.randint(0, 10, size=5),
+    ),
+    (
+        pd.Series(np.random.randint(0, 10, size=5)).astype('Int64'),
+        pd.Series(np.random.randint(0, 10, size=5)).astype('Int64'),
     ),
     (
         np.random.randint(0, 10, size=1),
@@ -431,6 +464,12 @@ def test_pearsoncc(truth, prediction):
             0,
         ),
         (
+            pd.Series(np.random.randint(0, 10, 5)).astype('Int64'),
+            pd.Series(np.random.randint(0, 10, 5)).astype('Int64'),
+            None,
+            0,
+        ),
+        (
             np.random.randint(0, 10, 100),
             np.random.randint(0, 10, 100),
             None,
@@ -460,6 +499,10 @@ def test_recall_precision_fscore(truth, prediction, labels, zero_division):
             labels,
             zero_division=zero_division,
         )
+        if isinstance(truth, pd.Series):
+            truth = np.array(list(truth))
+        if isinstance(prediction, pd.Series):
+            prediction = np.array(list(prediction))
         expected = sklearn_metric(
             truth,
             prediction,


### PR DESCRIPTION
Closes #17 

This applies the suggestion from #17 where we first convert truth / prediction to a list before converting it to a `np.array`.

Additional tests are added in various places to guarantee the following functions now work with `Int64`:

* `accuracy`
* `concordance_cc`
* `fscore`
* `mean_absolute_error`
* `mean_squared_error`
* `pearson_cc`
* `precision`
* `recall`
