### PR TITLE
DOC: add reference for CCC formula

### DIFF
--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -83,7 +83,10 @@ def concordance_cc(
                       \mu_\text{prediction}-\mu_\text{truth})^2}
 
     where :math:`\rho` is the Pearson correlation coefficient,
-    :math:`\mu` the mean and :math:`\sigma^2` the variance.
+    :math:`\mu` the mean
+    and :math:`\sigma^2` the variance.\ :footcite:`Lin1989`
+
+    .. footbibliography::
 
     Args:
         truth: ground truth values

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,6 +40,11 @@ extensions = [
 napoleon_use_ivar = True  # List of class attributes
 autodoc_inherit_docstrings = False  # disable docstring inheritance
 bibtex_bibfiles = ['refs.bib']
+# Don't check for DOIs as they will always work
+linkcheck_ignore = [
+    'https://doi.org/10.2307/2532051',
+    'https://doi.org/10.1109/34.990140',
+]
 
 # HTML --------------------------------------------------------------------
 html_theme = 'sphinx_audeering_theme'

--- a/docs/refs.bib
+++ b/docs/refs.bib
@@ -1,3 +1,13 @@
+@article{Lin1989,
+    author={Lin, Lawrence I-Kuei},
+    title={A concordance correlation coefficient to evaluate reproducibility},
+    journal={Biometrics},
+    volume={45},
+    issue={1},
+    pages={255--268},
+    doi={10.2307/2532051},
+    year={1989}
+}
 @article{Maio2002,
     author = {Maio, D. and Maltoni, D. and Cappelli, R. and Wayman, J. L. and Jain, A. K.},
     title = {FVC2000: Fingerprint verification competition},


### PR DESCRIPTION
I added the reference for our CCC formula. Unfortunately, it is not the exact same formula but reads

![image](https://user-images.githubusercontent.com/173624/153379785-e50f9c12-14fa-49ed-855b-ee4776db0ea6.png)

But if you start from two other formulas in the paper, namely

![image](https://user-images.githubusercontent.com/173624/153381754-7e101416-b4ee-4573-9e38-bcf8949ce770.png)

![image](https://user-images.githubusercontent.com/173624/153381795-f7e50c35-9e68-4900-9a63-5d1129c93ddb.png)

you will end up after 2-3 lines in our formula.


![image](https://user-images.githubusercontent.com/173624/153379858-c699b609-857e-4fdf-924c-d566ca3f1351.png)
