### PR TITLE
TST: adjust tests for new numpy version

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,9 @@
+numpy >=1.23.0
 pandas
 pyeer
 pytest
 pytest-flake8
 pytest-doctestplus
 pytest-cov
+scipy >=1.8.1
 sklearn

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,9 +1,7 @@
-numpy >=1.23.0
 pandas
 pyeer
 pytest
 pytest-flake8
 pytest-doctestplus
 pytest-cov
-scipy >=1.8.1
 sklearn

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -175,7 +175,7 @@ def test_equal_error_rate_warnings():
     # No imposter scores (division by 0)
     truth = np.array([1, 1])
     prediction = np.array([1, 1])
-    warning = 'invalid value encountered in true_divide'
+    warning = 'invalid value encountered in divide'
     with pytest.warns(RuntimeWarning, match=warning):
         eer, stats = audmetric.equal_error_rate(truth, prediction)
         pyeer_stats = pyeer.eer_info.get_eer_stats(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -175,7 +175,7 @@ def test_equal_error_rate_warnings():
     # No imposter scores (division by 0)
     truth = np.array([1, 1])
     prediction = np.array([1, 1])
-    warning = 'invalid value encountered in divide'
+    warning = 'invalid value encountered'
     with pytest.warns(RuntimeWarning, match=warning):
         eer, stats = audmetric.equal_error_rate(truth, prediction)
         pyeer_stats = pyeer.eer_info.get_eer_stats(


### PR DESCRIPTION
Fixes the failed test from https://github.com/audeering/audmetric/runs/7191290474?check_suite_focus=true as the warning message in `numpy` 1.23.0 changed from `invalid value encountered in true_divide` to `invalid value encountered in divide`.