### PR TITLE
TST: use pre-commit for flake8 checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,14 @@ jobs:
         pip install -r docs/requirements.txt
         pip install -r tests/requirements.txt
 
+    - name: Install pre-commit hooks
+      run: |
+        pre-commit install --install-hooks
+
+    - name: Code style check via pre-commit
+      run: |
+        pre-commit run --all-files
+
     - name: Test with pytest
       run: |
         python -m pytest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# Configuration of checks run by pre-commit
+#
+# The tests are executed in the CI pipeline,
+# see CONTRIBUTING.rst for further instructions.
+# You can also run the checks directly at the terminal, e.g.
+#
+# $ pre-commit install
+# $ pre-commit run --all-files
+#
+repos:
+-   repo: https://github.com/pycqa/flake8
+    rev: '5.0.4'
+    hooks:
+    -   id: flake8

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -30,6 +30,39 @@ This way, your installation always stays up-to-date,
 even if you pull new changes from the Github repository.
 
 
+Coding Convention
+-----------------
+
+We follow the PEP8_ convention for Python code
+and check for correct syntax with flake8_.
+Exceptions are defined under the ``[flake8]`` section
+in :file:`setup.cfg`.
+
+The checks are executed in the CI using `pre-commit`_.
+You can enable those checks locally by executing::
+
+    pip install -r tests/requirements.txt
+    pre-commit install
+    pre-commit run --all-files
+
+Afterwards flake8_ is executed
+every time you create a commit.
+
+You can also install flake8_
+and call it directly::
+
+    pip install flake8  # you might consider system wide installation
+    flake8
+
+It can be restricted to specific folders::
+
+    flake8 audfoo/ tests/
+
+.. _PEP8: http://www.python.org/dev/peps/pep-0008/
+.. _flake8: https://flake8.pycqa.org/en/latest/index.html
+.. _pre-commit: https://pre-commit.com
+
+
 Building the Documentation
 --------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,12 @@ addopts =
 xfail_strict = true
 
 [flake8]
-ignore =
-    W503  # math, https://github.com/PyCQA/pycodestyle/issues/513
-    __init__.py F401  # ignore unused imports
+exclude =
+    .eggs,
+    build,
+extend-ignore =
+    # math, https://github.com/PyCQA/pycodestyle/issues/513
+    W503,
+per-file-ignores =
+    # ignore unused imports
+    __init__.py: F401,

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,6 @@ setup_requires =
 
 [tool:pytest]
 addopts =
-    --flake8
     --doctest-plus
     --cov=audmetric
     --cov-fail-under=100

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,8 @@
+# numpy 1.24 has removed numpy.int,
+# which is needed by pyeer.
+# A fix is proposed at
+# https://github.com/manuelaguadomtz/pyeer/pull/10
+# until this is accepted we pin numpy
 numpy < 1.24
 pandas
 pre-commit

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -4,4 +4,4 @@ pyeer
 pytest
 pytest-doctestplus
 pytest-cov
-sklearn
+scikit-learn

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,7 +1,7 @@
 pandas
+pre-commit
 pyeer
 pytest
-pytest-flake8
 pytest-doctestplus
 pytest-cov
 sklearn

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
+numpy < 1.24
 pandas
 pre-commit
 pyeer


### PR DESCRIPTION
This uses [pre-commit](https://pre-commit.com) instead of `pytest` to execute the `flake8` tests.

It also fixes a few flake8 issues and adds a coding convention section to CONTRIBUTING.