### PR TITLE
DOC: use KaTeX and pre-render math on Github page

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,19 @@ jobs:
       with:
         python-version: '3.8'
 
+    - name: Set up Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 10.7
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+
+    - name: Prepare KaTeX server
+      run: |
+        npm install --global katex@${{ env.katex-version }}
 
     # PyPI package
     - name: Build and publish
@@ -40,7 +49,7 @@ jobs:
 
     - name: Build documentation
       run: |
-        python -m sphinx docs/ docs/_build/ -b html
+        python -m sphinx docs/ docs/_build/ -b html -D katex_prerender=1
 
     - name: Deploy documentation to Github pages
       uses: peaceiris/actions-gh-pages@v3

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = [
     'sphinx_autodoc_typehints',
     'sphinx.ext.viewcode',
     'sphinx_copybutton',
+    'sphinxcontrib.katex',  # has to be before jupyter_sphinx
 ]
 
 napoleon_use_ivar = True  # List of class attributes


### PR DESCRIPTION
Uses [sphinxcontrib-katex](https://github.com/hagenw/sphinxcontrib-katex) to render math equations and pre-render them in the publish docs for faster HTML page loading.