### PR TITLE
CI: ugrade to Node 16

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 10.7
+        node-version: '16.0'
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Upgrade Node to v16.0 for pre-rendering math in the published docs.