### PR TITLE
Speedup concordance_cc() and pearson_cc()

### DIFF
--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -106,8 +106,10 @@ def concordance_cc(
     """
     assert_equal_length(truth, prediction)
 
-    prediction = np.array(list(prediction))
-    truth = np.array(list(truth))
+    if not isinstance(truth, np.ndarray):
+        truth = np.array(list(truth))
+    if not isinstance(prediction, np.ndarray):
+        prediction = np.array(list(prediction))
 
     if len(prediction) < 2:
         return np.NaN
@@ -672,8 +674,10 @@ def pearson_cc(
     """
     assert_equal_length(truth, prediction)
 
-    prediction = np.array(list(prediction))
-    truth = np.array(list(truth))
+    if not isinstance(truth, np.ndarray):
+        truth = np.array(list(truth))
+    if not isinstance(prediction, np.ndarray):
+        prediction = np.array(list(prediction))
 
     if len(prediction) < 2 or prediction.std() == 0:
         return np.NaN


### PR DESCRIPTION
Relates to #41 

As discussed in #41 our current implementations of `audmetric.concordance_cc()` and `audmetric.pearson_cc()` could be faster when `numpy` arrays are provided as input as currently we convert them first to a list and then back to a `numpy` array. This pull request introduces a check and does the conversion only if they are not already `numpy` arrays.

As stated in https://github.com/audeering/audmetric/issues/41#issuecomment-1513055585 we are not going to introduce a `ignore` argument, but recommend to use `np.NaN` in the input instead, which will be handled in a separate pull request.

/cc @dkounadis 