### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,17 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
+Version 1.2.0 (2023/05/08)
+--------------------------
+
+* Added: ``audmetric.linkability()``
+* Changed: speedup ``audmetric.concordance_cc()``
+  and ``audmetric.pearson_cc()``
+  when providing ``truth``
+  and/or ``prediction``
+  as numpy arrays
+
+
 Version 1.1.6 (2023/01/03)
 --------------------------
 


### PR DESCRIPTION
I would propose to first make a release with the current state and afterwards continue with #43 and handling of `NaN` values for all functions.

![image](https://user-images.githubusercontent.com/173624/236827257-0aeadab1-7099-404f-b245-98f0e45ff9d6.png)
