### PR TITLE
TEST: remove pyeer dependency

### DIFF
--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,11 +1,4 @@
-# numpy 1.24 has removed numpy.int,
-# which is needed by pyeer.
-# A fix is proposed at
-# https://github.com/manuelaguadomtz/pyeer/pull/10
-# until this is accepted we pin numpy
-numpy < 1.24
 pandas
-pyeer
 pytest
 pytest-doctestplus
 pytest-cov

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-import pyeer.eer_info
 import pytest
 import sklearn.metrics
 
@@ -153,21 +152,19 @@ def test_accuracy(truth, prediction, labels, to_string):
     ]
 )
 def test_equal_error_rate(truth, prediction, expected_eer, expected_threshold):
+    r"""Test audmetric.equal_error_rate().
+
+    The expected values for EER and the thresholds
+    were calculated by the ``pyeer`` package,
+    see https://github.com/manuelaguadomtz/pyeer.
+
+    """
     eer, stats = audmetric.equal_error_rate(truth, prediction)
     # Check expected results
     assert type(eer) == float
     assert type(stats.threshold) == float
     assert eer == expected_eer
     assert stats.threshold == expected_threshold
-    # Compare to pyeer package
-    truth = np.array(truth)
-    prediction = np.array(prediction)
-    pyeer_stats = pyeer.eer_info.get_eer_stats(
-        prediction[truth],
-        prediction[~truth],
-    )
-    assert eer == pyeer_stats.eer
-    assert stats.threshold == pyeer_stats.eer_th
 
 
 def test_equal_error_rate_warnings():
@@ -178,12 +175,6 @@ def test_equal_error_rate_warnings():
     warning = 'invalid value encountered'
     with pytest.warns(RuntimeWarning, match=warning):
         eer, stats = audmetric.equal_error_rate(truth, prediction)
-        pyeer_stats = pyeer.eer_info.get_eer_stats(
-            prediction[truth],
-            prediction[~truth],
-        )
-        assert eer == pyeer_stats.eer
-        assert stats.threshold == pyeer_stats.eer_th
 
     # Curves to not overlap
     truth = np.array([1, 1, 0])
@@ -194,12 +185,6 @@ def test_equal_error_rate_warnings():
     )
     with pytest.warns(RuntimeWarning, match=warning):
         eer, stats = audmetric.equal_error_rate(truth, prediction)
-        pyeer_stats = pyeer.eer_info.get_eer_stats(
-            prediction[truth],
-            prediction[~truth],
-        )
-        assert eer == pyeer_stats.eer
-        assert stats.threshold == pyeer_stats.eer_th
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
As `pyeer` is no longer maintained and fails with newer versions of `numpy` (see https://github.com/manuelaguadomtz/pyeer/pull/10), we no longer use it inside the tests.