### PR TITLE
Speedup audmetric.detection_error_tradeoff()

### DIFF
--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -198,11 +198,9 @@ def confusion_matrix(
 
 def detection_error_tradeoff(
     truth: typing.Union[
-        typing.Union[bool, int],
         typing.Sequence[typing.Union[bool, int]]
     ],
     prediction: typing.Union[
-        typing.Union[bool, int, float],
         typing.Sequence[typing.Union[bool, int, float]]
     ],
 ) -> typing.Tuple[np.ndarray, np.ndarray, np.ndarray]:
@@ -346,11 +344,9 @@ def edit_distance(
 
 def equal_error_rate(
     truth: typing.Union[
-        typing.Union[bool, int],
         typing.Sequence[typing.Union[bool, int]]
     ],
     prediction: typing.Union[
-        typing.Union[bool, int, float],
         typing.Sequence[typing.Union[bool, int, float]]
     ],
 ) -> typing.Tuple[float, collections.namedtuple]:

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -197,12 +197,8 @@ def confusion_matrix(
 
 
 def detection_error_tradeoff(
-    truth: typing.Union[
-        typing.Sequence[typing.Union[bool, int]]
-    ],
-    prediction: typing.Union[
-        typing.Sequence[typing.Union[bool, int, float]]
-    ],
+    truth: typing.Sequence[typing.Union[bool, int]],
+    prediction: typing.Sequence[typing.Union[bool, int, float]],
 ) -> typing.Tuple[np.ndarray, np.ndarray, np.ndarray]:
     r"""Detection error tradeoff for verification experiments.
 
@@ -343,12 +339,8 @@ def edit_distance(
 
 
 def equal_error_rate(
-    truth: typing.Union[
-        typing.Sequence[typing.Union[bool, int]]
-    ],
-    prediction: typing.Union[
-        typing.Sequence[typing.Union[bool, int, float]]
-    ],
+    truth: typing.Sequence[typing.Union[bool, int]],
+    prediction: typing.Sequence[typing.Union[bool, int, float]],
 ) -> typing.Tuple[float, collections.namedtuple]:
     r"""Equal error rate for verification tasks.
 

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1,5 +1,4 @@
 import collections
-import operator
 import typing
 import warnings
 
@@ -228,8 +227,8 @@ def detection_error_tradeoff(
     whereas prediction values
     can also contain similarity scores, e.g. ``[0.8, 0.1, ...]``.
 
-    The implementation is identical with the one provided
-    by the pyeer_ package.
+    The implementation was inspired by pyeer.eer_stats.calculate_roc but has
+    been accelerated by using numpy-arrays instead of lists.
 
     .. _detection error tradeoff (DET): https://en.wikipedia.org/wiki/Detection_error_tradeoff
     .. _pyeer: https://github.com/manuelaguadomtz/pyeer
@@ -264,11 +263,13 @@ def detection_error_tradeoff(
     iscores_number = len(iscores)
 
     # Labeling genuine scores as 1 and impostor scores as 0
-    gscores = list(zip(gscores, [1] * gscores_number))
-    iscores = list(zip(iscores, [0] * iscores_number))
+    gscores = np.column_stack((gscores, np.ones(gscores_number, dtype=int)))
+    iscores = np.column_stack((iscores, np.zeros(iscores_number, dtype=int)))
 
     # Stacking scores
-    scores = np.array(sorted(gscores + iscores, key=operator.itemgetter(0)))
+    all_scores = np.concatenate([gscores, iscores])
+    sorted_indices = np.argsort(all_scores[:, 0])
+    scores = all_scores[sorted_indices]
     cumul = np.cumsum(scores[:, 1])
 
     # Grouping scores

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -97,6 +97,81 @@ def test_accuracy(truth, prediction, labels, to_string):
 
 
 @pytest.mark.parametrize(
+    'truth, prediction, expected_fmr, expected_fnmr, expected_threshold',
+    [
+        (
+            [1, 1, 0, 0],
+            [1, 1, 0, 0],
+            [1., 0.],
+            [0., 0.],
+            [0., 1.],
+        ),
+        (
+            [True, True, False, False],
+            [True, True, False, False],
+            [1., 0.],
+            [0., 0.],
+            [0., 1.],
+        ),
+        (
+            [True, True, False, False],
+            [1, 1, 0, 0],
+            [1., 0.],
+            [0., 0.],
+            [0., 1.],
+        ),
+        (  # similarities > 1 or < 0
+            [True, True, False, False],
+            [1.5, 1.5, -1., -1.],
+            [1., 0.],
+            [0., 0.],
+            [-1., 1.5],
+        ),
+        (  # unordered
+            [1, 0, 1, 1],
+            [0.5, 0.4, 0.8, 0.2],
+            [1., 1., 0., 0.],
+            [0., 1/3, 1/3, 2/3],
+            [0.2, 0.4, 0.5, 0.8],
+        ),
+        (  # mixed truth types
+            [1, False, 1, True],
+            [0.5, 0.4, 0.8, 0.2],
+            [1., 1., 0., 0.],
+            [0., 1/3, 1/3, 2/3],
+            [0.2, 0.4, 0.5, 0.8],
+        ),
+        # Non [1, 0, True, False] truth not allowed
+        pytest.param(
+            [1, 0.5, 0, 0],
+            [1, 1, 0, 0],
+            [1., 0.],
+            [0., 0.],
+            [0., 1.],
+            marks=pytest.mark.xfail(raises=ValueError),
+        ),
+    ]
+)
+def test_detection_error_tradeoff(truth,
+                                  prediction,
+                                  expected_fmr,
+                                  expected_fnmr,
+                                  expected_thresholds):
+    ret = audmetric.detection_error_tradeoff(truth, prediction)
+    # Check return types
+    assert len(ret) == 3  # fmr, fnmr, thresholds
+    for arr in ret:
+        assert type(arr) == np.ndarray
+        for val in arr:
+            assert isinstance(val, np.floating)
+    # Check return values
+    fmr, fnmr, thresholds = ret
+    np.testing.assert_almost_equal(fmr, expected_fmr)
+    np.testing.assert_almost_equal(fnmr, expected_fnmr)
+    np.testing.assert_almost_equal(thresholds, expected_thresholds)
+
+
+@pytest.mark.parametrize(
     'truth, prediction, expected_eer, expected_threshold',
     [
         (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -141,7 +141,7 @@ def test_accuracy(truth, prediction, labels, to_string):
             [0., 1/3, 1/3, 2/3],
             [0.2, 0.4, 0.5, 0.8],
         ),
-        # Non [1, 0, True, False] truth not allowed
+        # Float values not allowed in truth
         pytest.param(
             [1, 0.5, 0, 0],
             [1, 1, 0, 0],

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -97,7 +97,7 @@ def test_accuracy(truth, prediction, labels, to_string):
 
 
 @pytest.mark.parametrize(
-    'truth, prediction, expected_fmr, expected_fnmr, expected_threshold',
+    'truth, prediction, expected_fmr, expected_fnmr, expected_thresholds',
     [
         (
             [1, 1, 0, 0],


### PR DESCRIPTION
As Detection Error Tradeoff is often used for pairwise similarities, the input similarity truth vectors can be very large.
By convering parts of the `detection_error_tradeoff()` function to `numpy`, a meaningful acceleration can be achieved (see below).
@hagenw 

```python
import api  # local copy of the modified repo audmetric.core.api
import audmetric
import numpy as np
import time


num_samples = np.array([1e4, 1e5, 1e6, 1e7]).astype(int)

for n in num_samples:
    # Generate seeded random truth and similarity vectors
    np.random.seed(0)
    truth = np.random.rand(n,) > 0.8
    sim = np.random.randn(n,) + truth * 1.

    # old implementation
    t_start = time.perf_counter()
    det1 = audmetric.detection_error_tradeoff(truth, sim)
    t_stop = time.perf_counter()
    rt1 = t_stop - t_start

    # new implementation
    t_start = time.perf_counter()
    det2 = api.detection_error_tradeoff(truth, sim)
    t_stop = time.perf_counter()
    rt2 = t_stop - t_start

    for a, b in zip(det1, det2):
        np.testing.assert_allclose(a, b)

    print(f"{n} samples - Runtime old: {rt1:.3f}s, new: {rt2:.3f}s; "
          f"ratio: {(rt2/rt1):.3f}")
```

```
   10000 samples - Runtime old:  0.012s, new: 0.002s; ratio: 0.188
  100000 samples - Runtime old:  0.154s, new: 0.026s; ratio: 0.169
 1000000 samples - Runtime old:  1.916s, new: 0.289s; ratio: 0.151
10000000 samples - Runtime old: 21.873s, new: 3.515s; ratio: 0.161
```