### PR TITLE
Update wer to standard definition

### DIFF
--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1246,9 +1246,7 @@ def word_error_rate(
     assert_equal_length(truth, prediction)
 
     if norm not in ["truth", "longest"]:
-        raise ValueError(
-            f'norm must be one of ["truth", "longest"], got {norm}'
-        )
+        raise ValueError(f'norm must be one of ["truth", "longest"], got {norm}')
 
     wer = 0.0
 

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1246,7 +1246,7 @@ def word_error_rate(
     assert_equal_length(truth, prediction)
 
     if norm not in ["truth", "longest"]:
-        raise ValueError(f'norm must be one of ["truth", "longest"], got {norm}')
+        raise ValueError(f"'norm' must be one of 'truth', 'longest', got '{norm}'")
 
     wer = 0.0
 

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1186,6 +1186,7 @@ def weighted_confusion_error(
 def word_error_rate(
     truth: Sequence[Sequence[str]],
     prediction: Sequence[Sequence[str]],
+    symmetric: bool = False,
 ) -> float:
     r"""Word error rate based on edit distance.
 
@@ -1217,11 +1218,18 @@ def word_error_rate(
         t = [map[i] for i in t]
         p = [map[i] for i in p]
 
-        n = max(len(t), len(p))
+        if symmetric:
+            # n = max(len(t), len(p))
+            # n = n if n > 1 else 1
+            n = len(t)
+        else:
+            n = max(len(t), len(p))
         n = n if n > 1 else 1
+
         wer += edit_distance(t, p) / n
 
     num_samples = len(truth) if len(truth) > 1 else 1
+
     return float(wer / num_samples)
 
 

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1202,7 +1202,7 @@ def word_error_rate(
     as the edit distance divided by a normalization factor n.
     This represents the average editing cost per sequence item.
     The value of n depends on the ``norm`` parameter.
-    
+
     If ``norm`` is ``"truth"``,
     n is set to the reference (truth) length,
     following the Wikipedia formulation.

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1190,12 +1190,14 @@ def word_error_rate(
 ) -> float:
     r"""Word error rate based on edit distance.
 
-    The word error rate is computed by aggregating the mean edit distances
-    of each (truth, prediction)-pair and averaging the aggregated score
-    by the number of pairs.
+    The word error rate is computed by aggregating the normalized edit
+    distances of each (truth, prediction)-pair and averaging the
+    aggregated score by the number of pairs.
 
-    The mean edit distance of each (truth, prediction)-pair is computed
-    as an average of the edit distance over a normalization factor n.
+    The normalized edit distance of each (truth, prediction)-pair is computed
+    as the edit distance divided by a normalization factor n. This represents
+    the average editing cost per sequence item.
+
     The value of n depends on the symmetric parameter.
     If ``symmetric`` is ``False`` (default):
     n is set to the reference (truth) length, following the Wikipedia formulation

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1186,7 +1186,7 @@ def weighted_confusion_error(
 def word_error_rate(
     truth: Sequence[Sequence[str]],
     prediction: Sequence[Sequence[str]],
-    symmetric: bool = True,
+    symmetric: bool = False,
 ) -> float:
     r"""Word error rate based on edit distance.
 

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1230,11 +1230,12 @@ def word_error_rate(
         >>> prediction = [["lorm", "ipsum"], ["north", "wind"]]
         >>> word_error_rate(truth, prediction)
         0.5
-        >>> # Example showing asymmetric normalization (default)
         >>> truth = [["hello", "world"]]
         >>> prediction = [["xyz", "moon", "abc"]]
-        >>> word_error_rate(truth, prediction, symmetric=False)
+        >>> word_error_rate(truth, prediction)
         1.5
+        >>> word_error_rate(truth, prediction, symmetric=True)
+        1.0
 
     """
     assert_equal_length(truth, prediction)

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1190,10 +1190,25 @@ def word_error_rate(
 ) -> float:
     r"""Word error rate based on edit distance.
 
+    The word error rate is computed by aggregating the mean edit distances 
+    of each (truth, prediction)-pair and averaging the aggregated score 
+    by the number of pairs.
+
+    The mean edit distance of each (truth, prediction)-pair is computed
+    as an average of the edit distance over a normalization factor n.
+    The value of n depends on the symmetric parameter:
+
+    If symmetric=False (default):
+        n is set to the reference (truth) length
+    If symmetric=True:
+        n is set to the maximum length between truth and prediction:
+        n = max(len(t), len(p))
+
     Args:
         truth: ground truth strings
         prediction: predicted strings
-        symmetric:
+        symmetric: if True, normalizes by max length of truth and prediction,
+            otherwise normalizes by truth length. Defaults to False.
 
     Returns:
         word error rate

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1191,13 +1191,16 @@ def word_error_rate(
 ) -> float:
     r"""Word error rate based on edit distance.
 
-    The word error rate is computed by aggregating the normalized edit
-    distances of each (truth, prediction)-pair and averaging the
-    aggregated score by the number of pairs.
+    The word error rate is computed
+    by aggregating the normalized edit distances
+    of each (truth, prediction)-pair
+    and averaging the aggregated score
+    by the number of pairs.
 
-    The normalized edit distance of each (truth, prediction)-pair is computed
-    as the edit distance divided by a normalization factor n. This represents
-    the average editing cost per sequence item.
+    The normalized edit distance
+    of each (truth, prediction)-pair is computed
+    as the edit distance divided by a normalization factor n.
+    This represents the average editing cost per sequence item.
 
     The value of n depends on the norm parameter:
     If ``norm`` is ``"truth"``:

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1199,7 +1199,9 @@ def word_error_rate(
     The value of n depends on the symmetric parameter:
 
     If symmetric=False (default):
-        n is set to the reference (truth) length:
+        n is set to the reference (truth) length, following the Wikipedia formulation
+        where n is the number of words in the reference (N=S+D+C). This means WER can
+        be greater than 1 if the prediction sequence is longer than the reference:
 
         .. math::
 

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1220,7 +1220,7 @@ def word_error_rate(
         truth: ground truth strings
         prediction: predicted strings
         norm: normalization method, either "truth" or "longest".
-            "truth" normalizes by truth length (default),
+            "truth" normalizes by truth length,
             "longest" normalizes by max length of truth and prediction
 
     Returns:

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1186,7 +1186,7 @@ def weighted_confusion_error(
 def word_error_rate(
     truth: Sequence[Sequence[str]],
     prediction: Sequence[Sequence[str]],
-    symmetric: bool = False,
+    symmetric: bool = True,
 ) -> float:
     r"""Word error rate based on edit distance.
 

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1199,10 +1199,18 @@ def word_error_rate(
     The value of n depends on the symmetric parameter:
 
     If symmetric=False (default):
-        n is set to the reference (truth) length
+        n is set to the reference (truth) length:
+
+        .. math::
+
+            n = \text{len}(t)
+
     If symmetric=True:
         n is set to the maximum length between truth and prediction:
-        n = max(len(t), len(p))
+
+        .. math::
+
+            n = \max(\text{len}(t), \text{len}(p))
 
     Args:
         truth: ground truth strings
@@ -1221,6 +1229,11 @@ def word_error_rate(
         >>> prediction = [["lorm", "ipsum"], ["north", "wind"]]
         >>> word_error_rate(truth, prediction)
         0.5
+        >>> # Example showing asymmetric normalization (default)
+        >>> truth = [["hello", "world"]]
+        >>> prediction = [["xyz", "moon", "abc"]]
+        >>> word_error_rate(truth, prediction, symmetric=False)
+        1.5
 
     """
     assert_equal_length(truth, prediction)

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1217,7 +1217,7 @@ def word_error_rate(
         truth: ground truth strings
         prediction: predicted strings
         symmetric: if True, normalizes by max length of truth and prediction,
-            otherwise normalizes by truth length. Defaults to False.
+            otherwise normalizes by truth length
 
     Returns:
         word error rate

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1193,6 +1193,7 @@ def word_error_rate(
     Args:
         truth: ground truth strings
         prediction: predicted strings
+        symmetric:
 
     Returns:
         word error rate
@@ -1219,11 +1220,10 @@ def word_error_rate(
         p = [map[i] for i in p]
 
         if symmetric:
-            # n = max(len(t), len(p))
-            # n = n if n > 1 else 1
-            n = len(t)
-        else:
             n = max(len(t), len(p))
+        else:
+            n = len(t)
+
         n = n if n > 1 else 1
 
         wer += edit_distance(t, p) / n

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1203,16 +1203,19 @@ def word_error_rate(
     This represents the average editing cost per sequence item.
 
     The value of n depends on the norm parameter:
-    If ``norm`` is ``"truth"``:
-    n is set to the reference (truth) length, following the Wikipedia formulation
-    where n is the number of words in the reference (N=S+D+C). This means WER can
-    be greater than 1 if the prediction sequence is longer than the reference:
+
+    If ``norm`` is ``"truth"``,
+    n is set to the reference (truth) length,
+    following the Wikipedia formulation.
+    Here, n is the number of words in the reference.
+    This means WER can be greater than 1
+    if the prediction sequence is longer than the reference:
 
         .. math::
 
             n = \text{len}(t)
 
-    If ``norm`` is ``"longest"``:
+    If ``norm`` is ``"longest"``,
     n is set to the maximum length between truth and prediction:
 
         .. math::

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1202,8 +1202,7 @@ def word_error_rate(
     as the edit distance divided by a normalization factor n.
     This represents the average editing cost per sequence item.
 
-    The value of n depends on the norm parameter:
-
+    The value of n depends on the ``norm`` parameter.
     If ``norm`` is ``"truth"``,
     n is set to the reference (truth) length,
     following the Wikipedia formulation.

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1196,19 +1196,18 @@ def word_error_rate(
 
     The mean edit distance of each (truth, prediction)-pair is computed
     as an average of the edit distance over a normalization factor n.
-    The value of n depends on the symmetric parameter:
-
-    If symmetric=False (default):
-        n is set to the reference (truth) length, following the Wikipedia formulation
-        where n is the number of words in the reference (N=S+D+C). This means WER can
-        be greater than 1 if the prediction sequence is longer than the reference:
+    The value of n depends on the symmetric parameter.
+    If ``symmetric`` is ``False`` (default):
+    n is set to the reference (truth) length, following the Wikipedia formulation
+    where n is the number of words in the reference (N=S+D+C). This means WER can
+    be greater than 1 if the prediction sequence is longer than the reference:
 
         .. math::
 
             n = \text{len}(t)
 
-    If symmetric=True:
-        n is set to the maximum length between truth and prediction:
+    If ``symmetric`` is ``True``:
+    n is set to the maximum length between truth and prediction:
 
         .. math::
 

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1200,7 +1200,7 @@ def word_error_rate(
     the average editing cost per sequence item.
 
     The value of n depends on the norm parameter:
-    If ``norm`` is ``"truth"`` (default):
+    If ``norm`` is ``"truth"``:
     n is set to the reference (truth) length, following the Wikipedia formulation
     where n is the number of words in the reference (N=S+D+C). This means WER can
     be greater than 1 if the prediction sequence is longer than the reference:

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1190,8 +1190,8 @@ def word_error_rate(
 ) -> float:
     r"""Word error rate based on edit distance.
 
-    The word error rate is computed by aggregating the mean edit distances 
-    of each (truth, prediction)-pair and averaging the aggregated score 
+    The word error rate is computed by aggregating the mean edit distances
+    of each (truth, prediction)-pair and averaging the aggregated score
     by the number of pairs.
 
     The mean edit distance of each (truth, prediction)-pair is computed

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1201,8 +1201,8 @@ def word_error_rate(
     of each (truth, prediction)-pair is computed
     as the edit distance divided by a normalization factor n.
     This represents the average editing cost per sequence item.
-
     The value of n depends on the ``norm`` parameter.
+    
     If ``norm`` is ``"truth"``,
     n is set to the reference (truth) length,
     following the Wikipedia formulation.

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1228,7 +1228,7 @@ def word_error_rate(
 
     Raises:
         ValueError: if ``truth`` and ``prediction`` differ in length
-        ValueError: if ``norm`` is not one of ["truth", "longest"]
+        ValueError: if ``norm`` is not one of ``"truth"``, ``"longest"``
 
     Examples:
         >>> truth = [["lorem", "ipsum"], ["north", "wind", "and", "sun"]]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1004,11 +1004,11 @@ def test_word_error_rate_symmetric(truth, prediction, wer):
         ([[]], [[]], 0),
         ([[None]], [[]], 1.0),
         ([[None]], [["lorem"]], 1.0),
-        ([[None]], [["lorem", "ipsum"]], 2.0), # fail, expected value error
+        ([[None]], [["lorem", "ipsum"]], 2.0),
         ([["lorem"]], [[]], 1),
         ([[]], [["lorem"]], 1),
         ([["lorem", "ipsum"]], [["lorem"]], 0.5),
-        ([["lorem"]], [["lorem", "ipsum"]], 1.0), #  fail. expected value error
+        ([["lorem"]], [["lorem", "ipsum"]], 1.0),
         ([["lorem"]], [["lorem"]], 0),
         ([["lorem", "ipsum"]], [["lorm", "ipsum"]], 0.5),
         (
@@ -1021,7 +1021,7 @@ def test_word_error_rate_symmetric(truth, prediction, wer):
             [[]],
             0.0,
             marks=pytest.mark.xfail(raises=ValueError),
-        ), #decaivated - value error
+        ),
     ],
 )
 def test_word_error_rate_asymmetric(truth, prediction, wer):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -992,8 +992,8 @@ def _wer_jiwer(ref, ans):
         ),
     ],
 )
-def test_word_error_rate(truth, prediction, wer):
-    np.testing.assert_equal(audmetric.word_error_rate(truth, prediction), wer)
+def test_word_error_rate_symmetric(truth, prediction, wer):
+    np.testing.assert_equal(audmetric.word_error_rate(truth, prediction, symmetric=True), wer)
 
 
 
@@ -1023,11 +1023,11 @@ def test_word_error_rate(truth, prediction, wer):
         ), #decaivated - value error
     ],
 )
-def test_word_error_rate_symmetric(truth, prediction, wer):
+def test_word_error_rate_asymmetric(truth, prediction, wer):
     """Tests for symmetric word error rate.
 
     Currently it contains the uncontroversial, i.e passing tests.
     """
     np.testing.assert_equal(
-        audmetric.word_error_rate(truth, prediction, symmetric=True), wer
+        audmetric.word_error_rate(truth, prediction, symmetric=False), wer
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1023,5 +1023,7 @@ def test_word_error_rate_truth(truth, prediction, wer):
 
 def test_word_error_rate_invalid_norm():
     """Test that word_error_rate raises ValueError for invalid norm argument."""
-    with pytest.raises(ValueError, match=r'norm must be one of \["truth", "longest"\], got foo'):
+    with pytest.raises(
+        ValueError, match=r'norm must be one of \["truth", "longest"\], got foo'
+    ):
         audmetric.word_error_rate([[]], [[]], norm="foo")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -993,8 +993,9 @@ def _wer_jiwer(ref, ans):
     ],
 )
 def test_word_error_rate_symmetric(truth, prediction, wer):
-    np.testing.assert_equal(audmetric.word_error_rate(truth, prediction, symmetric=True), wer)
-
+    np.testing.assert_equal(
+        audmetric.word_error_rate(truth, prediction, symmetric=True), wer
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -953,19 +953,6 @@ def test_weighted_confusion_error(weights, num_elements, to_string):
     )
 
 
-def _wer_jiwer(ref, ans):
-    """Jiwer  Word Error Rate (WER) implementation.
-
-    Temporary wrapper during implmentation of feature
-
-    References:
-        - https://en.wikipedia.org/wiki/Word_error_rate
-    """
-    import jiwer
-
-    return jiwer.wer(" ".join(ref[0]), " ".join(ans[0]))
-
-
 @pytest.mark.parametrize(
     "truth,prediction,wer",
     [

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1024,6 +1024,6 @@ def test_word_error_rate_truth(truth, prediction, wer):
 def test_word_error_rate_invalid_norm():
     """Test that word_error_rate raises ValueError for invalid norm argument."""
     with pytest.raises(
-        ValueError, match=r'norm must be one of \["truth", "longest"\], got foo'
+        ValueError, match=r"'norm' must be one of 'truth', 'longest', got 'foo'"
     ):
         audmetric.word_error_rate([[]], [[]], norm="foo")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -994,3 +994,40 @@ def _wer_jiwer(ref, ans):
 )
 def test_word_error_rate(truth, prediction, wer):
     np.testing.assert_equal(audmetric.word_error_rate(truth, prediction), wer)
+
+
+
+@pytest.mark.parametrize(
+    "truth,prediction,wer",
+    [
+        ([[]], [[]], 0),
+        ([[None]], [[]], 1.0),
+        ([[None]], [["lorem"]], 1.0),
+        # ([[None]], [["lorem", "ipsum"]], 1.0), # fail, expected value error
+        ([["lorem"]], [[]], 1),
+        ([[]], [["lorem"]], 1),
+        ([["lorem", "ipsum"]], [["lorem"]], 0.5),
+        # ([["lorem"]], [["lorem", "ipsum"]], 0.5), #  fail. expected value error
+        ([["lorem"]], [["lorem"]], 0),
+        ([["lorem", "ipsum"]], [["lorm", "ipsum"]], 0.5),
+        (
+            [["lorem", "ipsum"], ["north", "wind", "and", "sun"]],
+            [["lorm", "ipsum"], ["north", "wind"]],
+            0.5,
+        ),
+        pytest.param(
+            [["lorem"], []],
+            [[]],
+            0.0,
+            marks=pytest.mark.xfail(raises=ValueError),
+        ), #decaivated - value error
+    ],
+)
+def test_word_error_rate_symmetric(truth, prediction, wer):
+    """Tests for symmetric word error rate.
+
+    Currently it contains the uncontroversial, i.e passing tests.
+    """
+    np.testing.assert_equal(
+        audmetric.word_error_rate(truth, prediction, symmetric=True), wer
+    )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1003,11 +1003,11 @@ def test_word_error_rate(truth, prediction, wer):
         ([[]], [[]], 0),
         ([[None]], [[]], 1.0),
         ([[None]], [["lorem"]], 1.0),
-        # ([[None]], [["lorem", "ipsum"]], 1.0), # fail, expected value error
+        ([[None]], [["lorem", "ipsum"]], 2.0), # fail, expected value error
         ([["lorem"]], [[]], 1),
         ([[]], [["lorem"]], 1),
         ([["lorem", "ipsum"]], [["lorem"]], 0.5),
-        # ([["lorem"]], [["lorem", "ipsum"]], 0.5), #  fail. expected value error
+        ([["lorem"]], [["lorem", "ipsum"]], 1.0), #  fail. expected value error
         ([["lorem"]], [["lorem"]], 0),
         ([["lorem", "ipsum"]], [["lorm", "ipsum"]], 0.5),
         (

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1019,3 +1019,9 @@ def test_word_error_rate_truth(truth, prediction, wer):
     np.testing.assert_equal(
         audmetric.word_error_rate(truth, prediction, norm="truth"), wer
     )
+
+
+def test_word_error_rate_invalid_norm():
+    """Test that word_error_rate raises ValueError for invalid norm argument."""
+    with pytest.raises(ValueError, match=r'norm must be one of \["truth", "longest"\], got foo'):
+        audmetric.word_error_rate([[]], [[]], norm="foo")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -979,9 +979,9 @@ def test_weighted_confusion_error(weights, num_elements, to_string):
         ),
     ],
 )
-def test_word_error_rate_symmetric(truth, prediction, wer):
+def test_word_error_rate_longest(truth, prediction, wer):
     np.testing.assert_equal(
-        audmetric.word_error_rate(truth, prediction, symmetric=True), wer
+        audmetric.word_error_rate(truth, prediction, norm="longest"), wer
     )
 
 
@@ -1011,11 +1011,11 @@ def test_word_error_rate_symmetric(truth, prediction, wer):
         ),
     ],
 )
-def test_word_error_rate_asymmetric(truth, prediction, wer):
+def test_word_error_rate_truth(truth, prediction, wer):
     """Tests for symmetric word error rate.
 
     Currently it contains the uncontroversial, i.e passing tests.
     """
     np.testing.assert_equal(
-        audmetric.word_error_rate(truth, prediction, symmetric=False), wer
+        audmetric.word_error_rate(truth, prediction, norm="truth"), wer
     )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -953,6 +953,19 @@ def test_weighted_confusion_error(weights, num_elements, to_string):
     )
 
 
+def _wer_jiwer(ref, ans):
+    """Jiwer  Word Error Rate (WER) implementation.
+
+    Temporary wrapper during implmentation of feature
+
+    References:
+        - https://en.wikipedia.org/wiki/Word_error_rate
+    """
+    import jiwer
+
+    return jiwer.wer(" ".join(ref[0]), " ".join(ans[0]))
+
+
 @pytest.mark.parametrize(
     "truth,prediction,wer",
     [


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/fafa8648-e6aa-4947-aa13-f2556127d07d)

closes #62 

Probably it is debatable whether the test organization is ok: I have split into two separate tests depending on the value of `symmetric`. Probably one could have have a single test that incorporates the value of symmetric into the parametrization. However I find that the long parameterizations are also hard to read. So I think this is justified.



## Summary by Sourcery

Update the word_error_rate function to support symmetric normalization and add corresponding test cases. Introduce a temporary wrapper for WER calculation using the jiwer library.

New Features:
- Introduce a new parameter 'symmetric' to the word_error_rate function, allowing for symmetric normalization by the maximum length of truth and prediction.

Enhancements:
- Add a temporary wrapper function _wer_jiwer to implement Word Error Rate (WER) using the jiwer library.

Tests:
- Add new test cases for the word_error_rate function to validate both symmetric and asymmetric normalization scenarios.
