### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
             python-version: '3.11'
           - os: ubuntu-latest
             python-version: '3.12'
+          - os: ubuntu-latest
+            python-version: '3.13'
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
     'Topic :: Scientific/Engineering',
 ]
 dependencies = [


### PR DESCRIPTION
Adds Python 3.13 as supported version to the Python package and enables tests for it in Ubuntu runners.

## Summary by Sourcery

Add support for Python 3.13 and update CI to test against it.

New Features:
- Add support for Python 3.13 in the project.

CI:
- Enable testing for Python 3.13 on Ubuntu runners in the CI workflow.