### PR TITLE
TST: update ruff and codespell versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.8
+    rev: v0.7.0
     hooks:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.3.0
     hooks:
       - id: codespell
         additional_dependencies:

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -943,7 +943,9 @@ def unweighted_average_bias(
         ...     reduction=lambda x: x[0] - x[1],
         ... )
         -1.0
-        >>> unweighted_average_bias([0, 1], [1, 0], ["male", "female"], metric=recall_per_class)
+        >>> unweighted_average_bias(
+        ...     [0, 1], [1, 0], ["male", "female"], metric=recall_per_class
+        ... )
         nan
         >>> unweighted_average_bias(
         ...     [0, 0, 0, 0],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ build-backend = 'setuptools.build_meta'
 # ----- codespell ---------------------------------------------------------
 [tool.codespell]
 builtin = 'clear,rare,informal,usage,names'
-skip = './audmetric.egg-info,./build,./docs/api,./docs/_templates'
+skip = './audmetric.egg-info,./build,./docs/api,./docs/_templates,LICENSE'
 
 
 # ----- pytest ------------------------------------------------------------

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -154,7 +154,7 @@ def test_detection_error_tradeoff(
     # Check return types
     assert len(ret) == 3  # fmr, fnmr, thresholds
     for arr in ret:
-        assert type(arr) == np.ndarray
+        assert type(arr) == np.ndarray  # noqa: E721
         for val in arr:
             assert isinstance(val, np.floating)
     # Check return values


### PR DESCRIPTION
Update `ruff` and `codespell` pre-commits to the versions we now use in other packages.