### PR TITLE
Remove Python 3.9 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ jobs:
         python-version: [ '3.10' ]
         include:
           - os: ubuntu-latest
-            python-version: '3.9'
-          - os: ubuntu-latest
             python-version: '3.11'
           - os: ubuntu-latest
             python-version: '3.12'

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import collections
 from collections.abc import Callable
 from collections.abc import Sequence

--- a/audmetric/core/utils.py
+++ b/audmetric/core/utils.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import Callable
 from collections.abc import Hashable
 from collections.abc import Sequence

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',


### PR DESCRIPTION
Remove support for Python 3.9

## Summary by Sourcery

Remove deprecated Python 3.9 support across the project

Enhancements:
- Drop Python 3.9 from supported versions

CI:
- Remove Python 3.9 from the GitHub Actions test matrix

Documentation:
- Remove Python 3.9 classifier from package metadata