### PR TITLE
TST: update ruff and codespell versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.0
+    rev: v0.13.3
     hooks:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies:

--- a/audmetric/core/api.py
+++ b/audmetric/core/api.py
@@ -614,7 +614,9 @@ def linkability(
         >>> truth = [1, 0] * int(samples / 2)
         >>> prediction = []
         >>> for _ in range(int(samples / 2)):
-        ...     prediction.extend([np.random.uniform(0, 0.2), np.random.uniform(0.8, 1.0)])
+        ...     prediction.extend(
+        ...         [np.random.uniform(0, 0.2), np.random.uniform(0.8, 1.0)]
+        ...     )
         >>> linkability(truth, prediction)
         0.9747999999999999
         >>> truth = [1, 0, 0, 0] * int(samples / 4)
@@ -1325,7 +1327,7 @@ def _matching_scores(
         raise ValueError(
             "'truth' is only allowed to contain "
             "[1, 0, True, False], "
-            'yours contains:\n'
+            "yours contains:\n"
             f"[{', '.join([str(t) for t in set(truth)])}]"
         )
 

--- a/audmetric/core/utils.py
+++ b/audmetric/core/utils.py
@@ -14,8 +14,7 @@ def assert_equal_length(
     r"""Assert truth and prediction have equal length."""
     if len(truth) != len(prediction):
         raise ValueError(
-            f"Truth and prediction differ in length: "
-            f"{len(truth)} != {len(prediction)}."
+            f"Truth and prediction differ in length: {len(truth)} != {len(prediction)}."
         )
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -616,7 +616,7 @@ def test_scores_per_subgroup_and_class(
 
 
 @pytest.mark.parametrize(
-    "truth,prediction,protected_variable,labels,subgroups,metric,reduction," "expected",
+    "truth,prediction,protected_variable,labels,subgroups,metric,reduction,expected",
     [
         (
             [],


### PR DESCRIPTION
Use newer versions of `ruff` and `codespell` in pre-commit.

## Summary by Sourcery

Update pre-commit hooks for ruff and codespell to newer versions and apply resulting formatting adjustments across the codebase

Enhancements:
- Bump ruff hook from v0.7.0 to v0.13.3
- Bump codespell hook from v2.3.0 to v2.4.1
- Reformat code in audmetric/core/api.py, core/utils.py, and tests to satisfy updated styling rules