### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
             python-version: '3.12'
           - os: ubuntu-latest
             python-version: '3.13'
+          - os: ubuntu-latest
+            python-version: '3.14'
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
     'Topic :: Scientific/Engineering',
 ]
 dependencies = [


### PR DESCRIPTION
Add support and tests for Python 3.14

## Summary by Sourcery

Add support for Python 3.14 by updating the CI matrix and package metadata

Enhancements:
- Support Python 3.14

CI:
- Add Python 3.14 to GitHub Actions test matrix

Documentation:
- Include Python 3.14 in project classifiers